### PR TITLE
Reflect current version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    helena (2.1.0)
+    helena (3.0.0)
       mongoid
       mongoid-simple-tags
       mongoid-tree
@@ -106,7 +106,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.14.0)
       i18n (>= 1.6, < 2)
-    ffi (1.13.1)
+    ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.5)
@@ -323,4 +323,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.3


### PR DESCRIPTION
The version was updated in commit 0035fa6, but the Gemfile.lock was out
of date. This causes version resolution problems when trying to install
gems from applications that use helena.